### PR TITLE
maybe fix automation eval?

### DIFF
--- a/datasets/automations/conftest.py
+++ b/datasets/automations/conftest.py
@@ -128,7 +128,9 @@ def pytest_generate_tests(metafunc: Any) -> None:
     metafunc.parametrize("model_output_file", [pytest.param(task) for task in tasks])
 
     model_id = metafunc.config.getoption("model_id")
-    metafunc.parametrize("model_id", [pytest.param(model_id)])
+    if model_id:
+
+        metafunc.parametrize("model_id", [pytest.param(model_id)])
 
 
 @pytest.fixture(name="test_path")

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ hass-client==1.2.0
 datasets==3.3.2
 
 # Dependencies for specific ML integrations
-openai==1.65.4
+openai==1.65.5
 google-generativeai==0.8.4
 ollama==0.4.7
 anthropic==0.49.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -8,7 +8,7 @@ hass-client==1.2.0
 datasets==3.3.2
 
 # Dependencies for specific ML integrations
-openai==1.65.5
+openai==1.65.4
 google-generativeai==0.8.4
 ollama==0.4.7
 anthropic==0.49.0


### PR DESCRIPTION
home-assistant-datasets automation eval --model_output_dir=reports/automations/2025.3.0
b datasets/automations

Results in errors as it attempts to pass model_id when it isn't needed by the functions. This removes it

Not sure if this is correct approach