### PR TITLE
Add support for setting a context device in an eval task and dataset flags

### DIFF
--- a/home_assistant_datasets/data_model.py
+++ b/home_assistant_datasets/data_model.py
@@ -1,6 +1,7 @@
 """Common librarys for collecting model outputs for evaluation."""
 
 from dataclasses import dataclass, field
+from functools import lru_cache
 from typing import Any
 import pathlib
 
@@ -33,6 +34,12 @@ class DatasetCard:
 
     urls: list[str]
     """More information about the dataset."""
+
+    count: int | None = None
+    """Number of times to run each task by default."""
+
+    version: str | None = None
+    """Current version of the dataset."""
 
     path: str | None = field(default=None)
     """Path to use for reading the dataset files instead of the current directory."""
@@ -129,6 +136,7 @@ def read_model(model_id: str) -> ModelConfig:
     )
 
 
+@lru_cache
 def read_dataset_card(dataset_card: pathlib.Path) -> DatasetCard:
     """Read a single dastaset configuration file."""
     data = yaml.load(dataset_card.read_text(), Loader=yaml.Loader)

--- a/home_assistant_datasets/tool/data_model.py
+++ b/home_assistant_datasets/tool/data_model.py
@@ -65,6 +65,9 @@ class Action(DataClassYAMLMixin):
     When specified as a list, the response may match any valid substring in the last.
     """
 
+    context_device: str | None = None
+    """Synthetic home device id for the current context of the request."""
+
     class Config(BaseConfig):
         forbid_extra_keys = False
 
@@ -98,6 +101,9 @@ class EvalTask(DataClassYAMLMixin):
 
     input_text: str
     """The conversation input text to state."""
+
+    context_device: str | None = None
+    """The device id for the current context."""
 
     expect_changes: dict[str, EntityState] | None = None
     """The device states to assert on."""
@@ -189,6 +195,7 @@ def generate_tasks(
                     record_id=record_id,
                     category=record.category,
                     input_text=sentence,
+                    context_device=action.context_device,
                     expect_changes=action.expect_changes,
                     ignore_changes=action.ignore_changes,
                     expect_response=action.expect_response,
@@ -201,6 +208,7 @@ def generate_tasks(
                         record_id=record_id,
                         category=record.category,
                         input_text=sentence,
+                        context_device=action.context_device,
                         expect_changes=action.expect_changes,
                         ignore_changes=action.ignore_changes,
                         expect_response=action.expect_response,


### PR DESCRIPTION
Improvements to eval harness to support new features:
- Ability to set a context device #115
- Extend dataset schema with a version
- Extend dataset schema with a default count for number of iterations #95