### PR TITLE
Update the assist dataset to remove incorrect commands and add additional coverage

### DIFF
--- a/datasets/assist/dataset_card.yaml
+++ b/datasets/assist/dataset_card.yaml
@@ -1,5 +1,6 @@
 ---
 name: assist
+version: v2
 description: |-
   A dataset built to exercise the Home Assistant LLM API. The homes for this
   dataset were synthetically generated using gpt-3.5, and then manually curated
@@ -7,5 +8,5 @@ description: |-
   were made intentionally more difficult than the existing assistant NLP for
   showcasing larger model reasoning capabilities.
 urls:
-- https://github.com/allenporter/home-assistant-datasets/tree/main/datasets/assist
-- https://developers.home-assistant.io/blog/2024/05/20/llm-api/
+  - https://github.com/allenporter/home-assistant-datasets/tree/main/datasets/assist
+  - https://developers.home-assistant.io/blog/2024/05/20/llm-api/

--- a/datasets/assist/dom1-pl/_fixtures.yaml
+++ b/datasets/assist/dom1-pl/_fixtures.yaml
@@ -2,22 +2,31 @@
 areas:
   - name: Kitchen
     id: kitchen
+    floor: Ground
   - name: Living Room
     id: living_room
+    floor: Ground
   - name: Dining Room
     id: dining_room
+    floor: Ground
   - name: Bedroom 1
     id: bedroom_1
+    floor: Ground
   - name: Bedroom 2
     id: bedroom_2
+    floor: Upstairs
   - name: Bedroom 3
     id: bedroom_3
+    floor: Upstairs
   - name: Bedroom 4
     id: bedroom_4
+    floor: Upstairs
   - name: Backyard
     id: backyard
+    floor: Ground
   - name: Garage
     id: garage
+    floor: Ground
 devices:
   - name: Kitchen Light
     id: kitchen_light

--- a/datasets/assist/dom1-pl/lights.yaml
+++ b/datasets/assist/dom1-pl/lights.yaml
@@ -27,3 +27,18 @@ tests:
         attributes:
           brightness: null
           color_mode: null
+  # Infer the area from the context device in the living room
+  - sentences:
+      - Please turn off the light
+    context_device: smart_speaker
+    setup:
+      light.living_room_light:
+        state: "on"
+        attributes:
+          brightness: 100
+    expect_changes:
+      light.living_room_light:
+        state: "off"
+        attributes:
+          brightness: null
+          color_mode: null

--- a/datasets/assist/dom1-pl/lights.yaml
+++ b/datasets/assist/dom1-pl/lights.yaml
@@ -88,3 +88,43 @@ tests:
         state: "on"
       light.bedroom_4_light:
         state: "on"
+
+  - sentences:
+      - Shut off the upstairs lights please
+      - Turn off the lights upstairs
+    setup:
+      light.bedroom_1_light:
+        state: "on"
+      light.bedroom_2_light:
+        state: "on"
+      light.bedroom_3_light:
+        state: "on"
+      light.bedroom_4_light:
+        state: "on"
+    expect_changes:
+      light.bedroom_2_light:
+        state: "off"
+      light.bedroom_3_light:
+        state: "off"
+      light.bedroom_4_light:
+        state: "off"
+
+  - sentences:
+      - Turn on all the upstairs lights
+      - Turn on all the bedroom lights upstairs
+    setup:
+      light.bedroom_1_light:
+        state: "off"
+      light.bedroom_2_light:
+        state: "off"
+      light.bedroom_3_light:
+        state: "off"
+      light.bedroom_4_light:
+        state: "off"
+    expect_changes:
+      light.bedroom_2_light:
+        state: "on"
+      light.bedroom_3_light:
+        state: "on"
+      light.bedroom_4_light:
+        state: "on"

--- a/datasets/assist/dom1-pl/lights.yaml
+++ b/datasets/assist/dom1-pl/lights.yaml
@@ -42,3 +42,49 @@ tests:
         attributes:
           brightness: null
           color_mode: null
+
+  # This is ambiguous and should not turn off anything
+  - sentences:
+      - Turn off the light
+    setup:
+      light.kitchen_light:
+        state: "on"
+        attributes:
+          brightness: 100
+      light.living_room_light:
+        state: "on"
+        attributes:
+          brightness: 100
+      light.dining_room_light:
+        state: "on"
+        attributes:
+          brightness: 100
+      light.bedroom_1_light:
+        state: "on"
+      light.bedroom_2_light:
+        state: "on"
+      light.bedroom_3_light:
+        state: "on"
+      light.bedroom_4_light:
+        state: "on"
+    expect_changes:
+      light.kitchen_light:
+        state: "on"
+        attributes:
+          brightness: 100
+      light.living_room_light:
+        state: "on"
+        attributes:
+          brightness: 100
+      light.dining_room_light:
+        state: "on"
+        attributes:
+          brightness: 100
+      light.bedroom_1_light:
+        state: "on"
+      light.bedroom_2_light:
+        state: "on"
+      light.bedroom_3_light:
+        state: "on"
+      light.bedroom_4_light:
+        state: "on"

--- a/datasets/assist/dom1-pl/todo.yaml
+++ b/datasets/assist/dom1-pl/todo.yaml
@@ -4,7 +4,6 @@ tests:
   - sentences:
       - add apples to my trader joe's list
       - put apples on the trader joes list
-      - put apples on the list
       - put apples on the shopping list
     expect_changes:
       todo.trader_joe_s:
@@ -15,7 +14,14 @@ tests:
       - Add history homework to my personal tasks
       - Add history homework to my tasks
       - Put history homework on my task list
-      - Add clean the kitchen to my todo list
     expect_changes:
       todo.personal_tasks:
         state: "1"
+  # Ambiguous sentence does not specify a list should not add anything
+  - sentences:
+      - put milk on the list
+    expect_changes:
+      todo.personal_tasks:
+        state: "0"
+      todo.trader_joe_s:
+        state: "0"

--- a/datasets/assist/home1-us/_fixtures.yaml
+++ b/datasets/assist/home1-us/_fixtures.yaml
@@ -56,6 +56,12 @@ devices:
       model: Roborock S5
       manufacturer: Roborock
       sw_version: 02.16.62
+  - name: Nest Hub
+    id: nest_hub
+    area: living_room
+    info:
+      model: Nest Hub
+      manufacturer: Google
   - name: Game Room Light
     id: game_room_light
     area: game_room
@@ -219,6 +225,24 @@ entities:
       device_class: sensor.SensorDeviceClass.BATTERY
       state_class: sensor.SensorStateClass.MEASUREMENT
       native_unit_of_measurement: "%"
+  - name: Nest Hub
+    id: media_player.nest_hub
+    area: living_room
+    device: nest_hub
+    state: playing
+    attributes:
+      device_class: media_player.MediaPlayerDeviceClass.SPEAKER
+      supported_features:
+        - media_player.MediaPlayerEntityFeature.PLAY
+        - media_player.MediaPlayerEntityFeature.PAUSE
+        - media_player.MediaPlayerEntityFeature.STOP
+        - media_player.MediaPlayerEntityFeature.VOLUME_STEP
+        - media_player.MediaPlayerEntityFeature.VOLUME_MUTE
+        - media_player.MediaPlayerEntityFeature.VOLUME_SET
+        - media_player.MediaPlayerEntityFeature.TURN_ON
+        - media_player.MediaPlayerEntityFeature.TURN_OFF
+        - media_player.MediaPlayerEntityFeature.NEXT_TRACK
+        - media_player.MediaPlayerEntityFeature.PREVIOUS_TRACK
   - name: Roborock Downstairs
     id: vacuum.roborock_downstairs
     area: living_room

--- a/datasets/assist/home1-us/_fixtures.yaml
+++ b/datasets/assist/home1-us/_fixtures.yaml
@@ -98,6 +98,13 @@ devices:
       model: MyQ Smart Garage Hub
       manufacturer: Chamberlain
       sw_version: 5.235
+  - name: Rear door lock
+    id: rear_door_lock
+    area: garage
+    info:
+      model: Encode Smart WiFi Deadbolt
+      manufacturer: Schlage
+      sw_version: 2.7.1
   - name: Bedroom 1 Light
     id: bedroom_1_light
     area: bedroom_1
@@ -338,6 +345,11 @@ entities:
         - onoff
       color_mode:
         - onoff
+  - name: Rear Door Lock
+    id: lock.rear_door_lock
+    area: garage
+    device: rear_door_lock
+    state: locked
   - name: Bedroom 1 Light
     id: light.bedroom_1_light
     area: bedroom_1

--- a/datasets/assist/home1-us/cover-garage.yaml
+++ b/datasets/assist/home1-us/cover-garage.yaml
@@ -3,7 +3,6 @@ category: cover
 tests:
   - sentences:
       - Close the garage door
-      - Close the garage door
     setup:
       cover.garage_door_opener:
         state: open

--- a/datasets/assist/home1-us/media-player.yaml
+++ b/datasets/assist/home1-us/media-player.yaml
@@ -1,0 +1,53 @@
+---
+category: media-player
+tests:
+  # Infer context from the device
+  - sentences:
+      - Set the volume to 0%
+    context_device: nest_hub
+    setup:
+      media_player.smart_speaker:
+        state: playing
+        attributes:
+          volume_level: 0.8
+      media_player.nest_hub:
+        state: playing
+        attributes:
+          volume_level: 0.8
+    expect_changes:
+      media_player.nest_hub:
+        attributes:
+          volume_level: 0.0
+
+  # Infer context from another device device
+  - sentences:
+      - Set the volume to 0%
+    context_device: smart_speaker
+    setup:
+      media_player.smart_speaker:
+        state: playing
+        attributes:
+          volume_level: 0.8
+      media_player.nest_hub:
+        state: playing
+        attributes:
+          volume_level: 0.8
+    expect_changes:
+      media_player.smart_speaker:
+        attributes:
+          volume_level: 0.0
+
+  # This is ambiguous since we don't know which area/device to target. Expect
+  # that devices are updated.
+  - sentences:
+      - Set the volume to 0%
+    setup:
+      media_player.smart_speaker:
+        state: playing
+        attributes:
+          volume_level: 0.8
+      media_player.nest_hub:
+        state: playing
+        attributes:
+          volume_level: 0.8
+    expect_changes: {}

--- a/datasets/assist/home1-us/smart-lock.yaml
+++ b/datasets/assist/home1-us/smart-lock.yaml
@@ -2,11 +2,9 @@
 category: lock
 tests:
   - sentences:
-      - Lock smart lock
       - Lock the front door lock
       - Lock the entry lock
       - Lock the smart lock
-      - Lock all the locks
     setup:
       lock.smart_lock:
         state: unlocked
@@ -14,13 +12,38 @@ tests:
       lock.smart_lock:
         state: locked
   - sentences:
-      - Unlock smart lock
       - Unlock the entry lock
       - Unlock the smart lock
-      - Unlock all the doors
     setup:
       lock.smart_lock:
         state: locked
     expect_changes:
       lock.smart_lock:
         state: unlocked
+  # Ambiguous sentence should not lock any locks and should instead ask for an area
+  - sentences:
+      - Lock all the locks please
+      - Lock the lock
+      - Lock the door
+    setup:
+      lock.smart_lock:
+        state: unlocked
+      lock.rear_door_lock:
+        state: unlocked
+    expect_changes:
+      lock.smart_lock:
+        state: unlocked
+      lock.rear_door_lock:
+        state: unlocked
+  - sentences:
+      - Unlock all the doors
+    setup:
+      lock.smart_lock:
+        state: locked
+      lock.rear_door_lock:
+        state: locked
+    expect_changes:
+      lock.smart_lock:
+        state: locked
+      lock.rear_door_lock:
+        state: locked

--- a/datasets/assist/home1-us/vacuum.yaml
+++ b/datasets/assist/home1-us/vacuum.yaml
@@ -5,7 +5,6 @@ tests:
       - Start Roborock Downstairs
       - Start Roborock Downstairs vacuum
       - Start Roborock
-      - Start the vacuum
       - Start vacuuming
       - Vacuum downstairs
       - Clean the living room
@@ -15,6 +14,18 @@ tests:
     expect_changes:
       vacuum.roborock_downstairs:
         state: cleaning
+  - sentences:
+      - Start the vacuum
+      - Please start cleaning
+      - Turn on the vacuum
+    context_device: nest_hub
+    setup:
+      vacuum.roborock_downstairs:
+        state: "off"
+    expect_changes:
+      vacuum.roborock_downstairs:
+        state: cleaning
+
   - sentences:
       - Return Roborock Downstairs to base
       - Roborock Downstairs return to base

--- a/datasets/assist/home5-cn/fan.yaml
+++ b/datasets/assist/home5-cn/fan.yaml
@@ -5,7 +5,7 @@ tests:
       - Turn on the bedroom 1 fan
       - Turn on the bedroom fan
       - Turn on the fan in the bedroom
-      - Turn on the fans
+      - Turn on the fan
     setup:
       fan.bedroom_fan:
         state: "off"
@@ -16,7 +16,7 @@ tests:
           percentage: 100
   - sentences:
       - Turn off the bedroom fan
-      - Turn off all the fans
+      - Turn off the fan
     setup:
       fan.bedroom_fan:
         state: "on"

--- a/datasets/assist/home7-dk/_fixtures.yaml
+++ b/datasets/assist/home7-dk/_fixtures.yaml
@@ -2,14 +2,19 @@
 areas:
   - name: Living Room
     id: living_room
+    floor: First
   - name: Kitchen
     id: kitchen
+    floor: First
   - name: Bedroom 1
     id: bedroom_1
+    floor: Second
   - name: Bedroom 2
     id: bedroom_2
+    floor: Third
   - name: Rooftop Terrace
     id: rooftop_terrace
+    floor: Third
 devices:
   - name: Living Room Light
     id: living_room_light


### PR DESCRIPTION
- Add commands that exercise device context like "turn off the light" when in an area
- Assert that ambiguous commands are not acted upon (e.g. like lock all the doors) 
- Remove tests for multiple todo lists that are not aligned with the instructions

fixes #115
Issue #13