### PR TITLE
Add question tasks for calendar and todo

### DIFF
--- a/datasets/questions/urban-loft-au/_fixtures.yaml
+++ b/datasets/questions/urban-loft-au/_fixtures.yaml
@@ -74,6 +74,10 @@ devices:
       model: Weather Underground
       manufacturer: Weather Underground
       sw_version: 2.2.2
+  - name: Tasks
+    id: tasks
+  - name: Personal
+    id: personal
 entities:
   - name: Living Room
     id: light.living_room
@@ -183,3 +187,19 @@ entities:
       native_temperature: 72
       humidity: 60
       native_wind_speed: 5
+  - name: Tasks
+    id: todo.tasks
+    device: tasks
+    attributes:
+      supported_features:
+        - todo.TodoListEntityFeature.CREATE_TODO_ITEM
+        - todo.TodoListEntityFeature.DELETE_TODO_ITEM
+      todo_items: []
+  - name: Personal
+    id: calendar.personal
+    device: personal
+    attributes:
+      supported_features:
+        - calendar.CalendarEntityFeature.CREATE_EVENT
+        - calendar.CalendarEntityFeature.DELETE_EVENT
+        - calendar.CalendarEntityFeature.UPDATE_EVENT

--- a/datasets/questions/urban-loft-au/_home.yaml
+++ b/datasets/questions/urban-loft-au/_home.yaml
@@ -79,3 +79,8 @@ devices:
         model: Weather Underground
         manufacturer: Weather Underground
         sw_version: 2.2.2
+services:
+  - name: Tasks
+    device_type: todo-list
+  - name: Personal
+    device_type: calendar

--- a/datasets/questions/urban-loft-au/calendar.yaml
+++ b/datasets/questions/urban-loft-au/calendar.yaml
@@ -1,0 +1,92 @@
+---
+category: calendar
+tests:
+  - sentences:
+      - What classes do I have today?
+      - What classes are on my personal calendar today?
+    context_now: 2025-04-02 08:30+10:00
+    setup:
+      calendar.personal:
+        attributes:
+          events:
+            - summary: Chemistry class
+              start: 2025-04-02 11:00+10:00
+              end: 2025-04-02 11:55+10:00
+            - summary: Dinner with Liza
+              description: Meet up with Liza, don't forget to bring flowers
+              location: Butcher's Prime Restaurant
+              start: 2025-04-02 19:00+10:00
+              end: 2025-04-02 20:30+10:00
+    expect_response:
+      - chemistry
+
+  - sentences:
+      - Who am I meeting for dinner?
+      - According to my personal calendar, who am I meeting for dinner?
+    context_now: 2025-04-02 08:30+10:00
+    setup:
+      calendar.personal:
+        attributes:
+          events:
+            - summary: Chemistry class
+              start: 2025-04-02 11:00+10:00
+              end: 2025-04-02 11:55+10:00
+            - summary: Dinner with Liza
+              description: Don't forget to bring flowers
+              location: Peninsula CR Steak & Seafood Grill
+              start: 2025-04-02 19:00+10:00
+              end: 2025-04-02 20:30+10:00
+    expect_response:
+      - Liza
+
+  - sentences:
+      - Am I leaving the house today?
+      - Do i have any personal calendar events away from home today?
+    context_now: 2025-04-02 08:30+10:00
+    setup:
+      calendar.personal:
+        attributes:
+          events:
+            - summary: Chemistry class
+              start: 2025-04-02 11:00+10:00
+              end: 2025-04-02 11:55+10:00
+              location:
+            - summary: Dinner with Liza
+              description: Meet up with Liza, don't forget to bring flowers
+              location: Peninsula CR Steak & Seafood Grill
+              start: 2025-04-02 19:00+10:00
+              end: 2025-04-02 20:30+10:00
+    expect_response:
+      - "yes"
+      - dinner
+      - school
+      - class
+
+  - sentences:
+      - Are we leaving the house today?
+      - According to my personal calendar, are we leaving the house today?
+      - According to my personal calendar, do I have any events away from home today?
+    context_now: 2025-04-02 08:30+10:00
+    setup:
+      calendar.personal:
+        attributes:
+          events:
+            - summary: Rest & Relax
+              location: Home
+              start: 2025-04-02 08:00+10:00
+              end: 2025-04-02 11:55+10:00
+            - summary: Clean the garage
+              location: Home
+              start: 2025-04-02 13:00+10:00
+              end: 2025-04-02 14:25+10:00
+            - summary: Order delivery
+              location: Home
+              start: 2025-04-02 18:00+10:00
+              end: 2025-04-02 18:15+10:00
+            - summary: Netflix w/ Liza
+              location: Home
+              start: 2025-04-02 18:00+10:00
+              end: 2025-04-02 20:25+10:00
+    expect_response:
+      - "no"
+      - nothing

--- a/datasets/questions/urban-loft-au/calendar.yaml
+++ b/datasets/questions/urban-loft-au/calendar.yaml
@@ -17,6 +17,10 @@ tests:
               location: Butcher's Prime Restaurant
               start: 2025-04-02 19:00+10:00
               end: 2025-04-02 20:30+10:00
+            - summary: Cynthia's Birthday
+              description: Remember to give her a phone call.
+              start: 2025-04-06
+              end: 2025-04-06
     expect_response:
       - chemistry
 
@@ -36,6 +40,10 @@ tests:
               location: Peninsula CR Steak & Seafood Grill
               start: 2025-04-02 19:00+10:00
               end: 2025-04-02 20:30+10:00
+            - summary: Cynthia's Birthday
+              description: Remember to give her a phone call.
+              start: 2025-04-06
+              end: 2025-04-06
     expect_response:
       - Liza
 
@@ -87,6 +95,67 @@ tests:
               location: Home
               start: 2025-04-02 18:00+10:00
               end: 2025-04-02 20:25+10:00
+            - summary: Cynthia's Birthday
+              description: Remember to give her a phone call.
+              start: 2025-04-06
+              end: 2025-04-06
     expect_response:
       - "no"
       - nothing
+
+  # Here we're exercising that the prompt asks to search the whole week, not just today
+  - sentences:
+      - How many nights this week do I need to cook?
+      - From my personal calendar, how many nights do I need to cook this week?
+    context_now: 2025-04-02 08:30+10:00
+    setup:
+      calendar.personal:
+        attributes:
+          events:
+            - summary: Cook Dinner
+              location: Home
+              start: 2025-04-02 19:00+10:00
+              end: 2025-04-02 20:30+10:00
+            - summary: Cook Dinner
+              location: Home
+              start: 2025-04-04 19:00+10:00
+              end: 2025-04-04 20:30+10:00
+            - summary: Cook Dinner
+              location: Home
+              start: 2025-04-05 19:00+10:00
+              end: 2025-04-05 20:30+10:00
+            - summary: Cynthia's Birthday
+              description: Remember to give her a phone call.
+              start: 2025-04-06
+              end: 2025-04-06
+    expect_response:
+      - "3"
+      - three
+
+  # Here we're exercising that the prompt asks to search the whole week, not just today
+  - sentences:
+      - Is anyone coming to visit?
+      - According to my calendar, is anyone visiting?
+    context_now: 2025-04-02 08:30+10:00
+    setup:
+      calendar.personal:
+        attributes:
+          events:
+            - summary: Cook Dinner
+              location: Home
+              start: 2025-04-02 19:00+10:00
+              end: 2025-04-02 20:30+10:00
+            - summary: Liza visit
+              location: Home
+              start: 2025-04-05
+              end: 2025-04-07
+            - summary: Cynthia's Birthday
+              description: Remember to give her a phone call.
+              start: 2025-04-06
+              end: 2025-04-06
+            - summary: Cook Dinner
+              location: Home
+              start: 2025-04-05 19:00+10:00
+              end: 2025-04-05 20:30+10:00
+    expect_response:
+      - liza

--- a/datasets/questions/urban-loft-au/todo.yaml
+++ b/datasets/questions/urban-loft-au/todo.yaml
@@ -1,0 +1,55 @@
+---
+category: todo
+tests:
+  - sentences:
+      - How many items are on my task list?
+    setup:
+      todo.tasks:
+        attributes:
+          todo_items:
+            - summary: Call Liza
+              status: needs_action
+            - summary: Repair the terrace light fixture
+              status: needs_action
+    expect_response:
+      - "2"
+
+  - sentences:
+      - Who is on my task list to call?
+      - Who do i need to call?
+    setup:
+      todo.tasks:
+        attributes:
+          todo_items:
+            - summary: Call Liza
+              status: needs_action
+            - summary: Repair the terrace light fixture
+              status: needs_action
+    expect_response:
+      - Liza
+
+  - sentences:
+      - What chores around the house do I need to complete?
+    setup:
+      todo.tasks:
+        attributes:
+          todo_items:
+            - summary: Call Liza
+              status: needs_action
+            - summary: Repair the terrace light fixture
+              status: needs_action
+    expect_response:
+      - terrace light
+
+  - sentences:
+      - What's is on my task list to buy at the grocery store?
+    setup:
+      todo.tasks:
+        attributes:
+          todo_items:
+            - summary: Buy salad
+              status: needs_action
+            - summary: Repair the terrace light fixture
+              status: needs_action
+    expect_response:
+      - salad

--- a/home_assistant_datasets/tool/data_model.py
+++ b/home_assistant_datasets/tool/data_model.py
@@ -4,13 +4,14 @@ This file defines dataclasses that hold data for the eval run, essentially the
 output of parsing the yaml files.
 """
 
-import logging
-from typing import Any
+from collections.abc import Generator
 import dataclasses
 from dataclasses import dataclass, field
-from collections.abc import Generator
+import datetime
+import logging
 import pathlib
 from slugify import slugify
+from typing import Any
 
 from mashumaro.mixins.yaml import DataClassYAMLMixin
 
@@ -68,6 +69,9 @@ class Action(DataClassYAMLMixin):
     context_device: str | None = None
     """Synthetic home device id for the current context of the request."""
 
+    context_now: datetime.datetime | None = None
+    """The current time to use during tests."""
+
     class Config(BaseConfig):
         forbid_extra_keys = False
 
@@ -104,6 +108,9 @@ class EvalTask(DataClassYAMLMixin):
 
     context_device: str | None = None
     """The device id for the current context."""
+
+    context_now: datetime.datetime | None = None
+    """The current time for the current context."""
 
     expect_changes: dict[str, EntityState] | None = None
     """The device states to assert on."""
@@ -196,6 +203,7 @@ def generate_tasks(
                     category=record.category,
                     input_text=sentence,
                     context_device=action.context_device,
+                    context_now=action.context_now,
                     expect_changes=action.expect_changes,
                     ignore_changes=action.ignore_changes,
                     expect_response=action.expect_response,
@@ -209,6 +217,7 @@ def generate_tasks(
                         category=record.category,
                         input_text=sentence,
                         context_device=action.context_device,
+                        context_now=action.context_now,
                         expect_changes=action.expect_changes,
                         ignore_changes=action.ignore_changes,
                         expect_response=action.expect_response,

--- a/home_assistant_datasets/tool/fixtures.py
+++ b/home_assistant_datasets/tool/fixtures.py
@@ -115,6 +115,21 @@ def eval_output_file_fixture(model_id: str, eval_task: EvalTask) -> pathlib.Path
     return pathlib.Path(f"{eval_task.output_dir}/{model_id}/{eval_task.task_id}.yaml")
 
 
+@pytest.fixture(name="context_now", autouse=True)
+def context_now_fixture(
+    eval_task: EvalTask,
+) -> Generator[datetime.datetime | None, None, None]:
+    """Fixture to set "now" based on the eval task context."""
+    if eval_task.context_now is None:
+        yield None
+        return
+
+    with patch(
+        "homeassistant.util.dt.now", return_value=eval_task.context_now
+    ) as now_dt:
+        yield now_dt
+
+
 @pytest.fixture(name="context_device_id")
 def context_device_id_fixture(
     synthetic_home_config_entry: Any,


### PR DESCRIPTION
Add question tasks for calendar and todo lists. This requires extending the fixtures with ability to set "now" based on calendar events.

#116