### PR TITLE
Move Conversation Agent handling to a submodule

### DIFF
--- a/home_assistant_datasets/__init__.py
+++ b/home_assistant_datasets/__init__.py
@@ -4,6 +4,7 @@
 
 __all__ = [
     "tool",
+    "agent",
     "data_model",
     "model_client",
     "secrets",

--- a/home_assistant_datasets/agent/__init__.py
+++ b/home_assistant_datasets/agent/__init__.py
@@ -1,0 +1,36 @@
+"""Conversation agent module.
+
+This module is a thin wrapper around the Conversation Agent process service,
+tied to a simple interface to handle things like rate limiting, timing,
+and retries.
+
+This module is primarily used during data collection / scraping.
+"""
+
+from . import rate_limit, retryable, service_call, timing
+from .agent import ConversationAgent
+
+
+__all__ = [
+    "ConversatioAgent",
+    "create_default_agent",
+    "service_call",
+    "rate_limit",
+    "retryable",
+    "timing",
+]
+
+
+def create_default_agent(
+    conversation_agent_id: str, rpm: int | None = None
+) -> ConversationAgent:
+    """Create the conversation agent client id.
+
+    Note that this should be long lived in order for rate limiting to be effective.
+    """
+    agent = service_call.create_agent(conversation_agent_id)
+    agent = timing.timed_agent(agent)
+    if rpm:
+        agent = rate_limit.wrap_rate_limit(agent, rpm)
+    agent = retryable.wrap_retryable(agent)
+    return agent

--- a/home_assistant_datasets/agent/agent.py
+++ b/home_assistant_datasets/agent/agent.py
@@ -1,0 +1,18 @@
+"""Conversation agent module."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+
+class ConversationAgent(ABC):
+    """A simple client library for calling a conversation agent."""
+
+    @abstractmethod
+    async def async_process(self, hass: HomeAssistant, text: str) -> str:
+        """Process a text input and return the response."""
+
+    @abstractmethod
+    def trace_context(self) -> dict[str, Any]:
+        """Record any relevant trace context captured during the requests."""

--- a/home_assistant_datasets/agent/rate_limit.py
+++ b/home_assistant_datasets/agent/rate_limit.py
@@ -1,0 +1,52 @@
+"""Rate limiter to avoid throttling from APIs."""
+
+from typing import Any
+
+from pyrate_limiter import (
+    Duration,
+    Rate,
+    Limiter,
+)
+
+from homeassistant.core import HomeAssistant
+
+from .agent import ConversationAgent
+
+__all__ = [
+    "wrap_rate_limit",
+]
+
+MAX_DELAY = 60 * 1000  # 1 minute
+
+
+def _create_limiter(rpm: int) -> Limiter:
+    """Create a rate limiter."""
+    rate = Rate(rpm, Duration.MINUTE)
+    return Limiter(rate, max_delay=MAX_DELAY)
+
+
+class RateLimitedAgent(ConversationAgent):
+    """A client library for a conversation agent service call."""
+
+    def __init__(self, agent: ConversationAgent, rate_limiter: Limiter) -> None:
+        """Initialize the agent."""
+        self._agent = agent
+        self._rate_limiter = rate_limiter
+
+    async def async_process(self, hass: HomeAssistant, text: str) -> str:
+        """Process a text input and return the response."""
+        if self._rate_limiter:
+            await self._rate_limiter.try_acquire("item")  # type: ignore[misc]
+        return await self._agent.async_process(hass, text)
+
+    def trace_context(self) -> dict[str, Any]:
+        """Record any relevant trace context captured during the requests."""
+        return self._agent.trace_context()
+
+
+def wrap_rate_limit(agent: ConversationAgent, rpm: int) -> ConversationAgent:
+    """Rate limit the specified agent.
+
+    Note that this should be long lived in order for rate limiting to be effective.
+    """
+    return RateLimitedAgent(agent, _create_limiter(rpm))

--- a/home_assistant_datasets/agent/retryable.py
+++ b/home_assistant_datasets/agent/retryable.py
@@ -1,0 +1,66 @@
+"""A wrapper to make a conversation agent retryable."""
+
+import asyncio
+import logging
+import json
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from .agent import ConversationAgent
+
+__all__ = [
+    "wrap_retryable",
+]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+TIMEOUT = 40
+MAX_TRIES = 3
+
+
+class RetryableAgent(ConversationAgent):
+    """A retryable conversation agent wrapper."""
+
+    def __init__(self, agent: ConversationAgent) -> None:
+        """Initialize the agent."""
+        self._agent = agent
+        self._tries = 0
+
+    async def async_process(self, hass: HomeAssistant, text: str) -> str:
+        """Process a text input and return the response."""
+        # Run the conversation agent
+        self._tries = 0
+        response = ""
+        retryable = True
+        while self._tries < MAX_TRIES and retryable:
+            self._tries += 1
+            retryable = False
+            _LOGGER.debug("Prompt: %s", text)
+            try:
+                async with asyncio.timeout(TIMEOUT):
+                    response = await self._agent.async_process(hass, text)
+            except (HomeAssistantError, TypeError, json.JSONDecodeError) as err:
+                response = str(err)
+            except (TimeoutError, asyncio.CancelledError):
+                _LOGGER.debug("Timeout error (tries=%s)", self._tries)
+                response = f"Timeout (after {self._tries} tries)"
+                retryable = True
+            await hass.async_block_till_done()
+            _LOGGER.debug("Response: %s", response)
+
+        return response
+
+    def trace_context(self) -> dict[str, Any]:
+        """Record any relevant trace context captured during the requests."""
+        context = self._agent.trace_context()
+        context["tries"] = self._tries
+        return context
+
+
+def wrap_retryable(agent: ConversationAgent) -> ConversationAgent:
+    """Wrap the agent with retry logic, returning errors as text."""
+    return RetryableAgent(agent)

--- a/home_assistant_datasets/agent/service_call.py
+++ b/home_assistant_datasets/agent/service_call.py
@@ -1,0 +1,85 @@
+"""The default conversation agent implemented with a service call."""
+
+import datetime
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant, Context
+from homeassistant.components.conversation import trace
+from homeassistant.helpers import llm
+
+from .agent import ConversationAgent
+
+
+__all__ = [
+    "create_agent",
+]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def dump_conversation_trace(trace: trace.ConversationTrace) -> list[dict[str, Any]]:
+    """Serialize the conversation trace for evaluation."""
+    trace_data = trace.as_dict()
+    trace_events = trace_data["events"]
+    result = []
+    for trace_event in trace_events:
+        trace_event_data = trace_event["data"]
+        data = {}
+        for k, v in trace_event_data.items():
+            if isinstance(v, Context):
+                v = dict(v.as_dict())
+            if isinstance(v, list) and v and isinstance(v[0], llm.Tool):
+                v = [
+                    {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": str(tool.parameters),
+                    }
+                    for tool in v
+                ]
+            data[k] = v
+        values: dict[str, Any] = {
+            "event_type": str(trace_event["event_type"]),
+            "data": data,
+        }
+        if ts_str := trace_event.get("timestamp"):
+            values["timestamp"] = datetime.datetime.fromisoformat(ts_str)
+        result.append(values)
+    return result
+
+
+class ServiceCall(ConversationAgent):
+    """A client library for a conversation agent service call."""
+
+    def __init__(self, agent_id: str) -> None:
+        """Initialize the agent."""
+        self._agent_id = agent_id
+
+    async def async_process(self, hass: HomeAssistant, text: str) -> str:
+        """Process a text input and return the response."""
+        _LOGGER.debug("hass.services.async_call=%s", hass.services.async_call)
+        service_response = await hass.services.async_call(
+            "conversation",
+            "process",
+            {"agent_id": self._agent_id, "text": text},
+            blocking=True,
+            return_response=True,
+        )
+        assert service_response
+        response = service_response["response"]
+        return str(response["speech"]["plain"]["speech"])  # type: ignore[call-overload, index]
+
+    def trace_context(self) -> dict[str, Any]:
+        """Record any relevant trace context captured during the requests."""
+        conversation_trace = []
+        if (traces := trace.async_get_traces()) and (last_trace := traces[-1]):
+            conversation_trace = dump_conversation_trace(last_trace)
+        return {
+            "conversation_trace": conversation_trace,
+        }
+
+
+def create_agent(agent_id: str) -> ConversationAgent:
+    """Create a conversation agent service call wrapper."""
+    return ServiceCall(agent_id)

--- a/home_assistant_datasets/agent/timing.py
+++ b/home_assistant_datasets/agent/timing.py
@@ -1,0 +1,47 @@
+"""A wrapper to make a conversation agent retryable."""
+
+import datetime
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from .agent import ConversationAgent
+
+
+__all__ = [
+    "timed_agent",
+]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class TimedAgent(ConversationAgent):
+    """A conversation agent wrapper that tracks called durations."""
+
+    def __init__(self, agent: ConversationAgent) -> None:
+        """Initialize the agent."""
+        self._agent = agent
+        self._elapsed: datetime.timedelta | None = None
+
+    async def async_process(self, hass: HomeAssistant, text: str) -> str:
+        """Process a text input and return the response."""
+        start = datetime.datetime.now()
+        try:
+            return await self._agent.async_process(hass, text)
+        finally:
+            self._elapsed = datetime.datetime.now() - start
+
+    def trace_context(self) -> dict[str, Any]:
+        """Record any relevant trace context captured during the requests."""
+        context = self._agent.trace_context()
+        if self._elapsed is not None:
+            duration_ms = self._elapsed / datetime.timedelta(milliseconds=1)
+            context["duration_ms"] = duration_ms
+        return context
+
+
+def timed_agent(agent: ConversationAgent) -> ConversationAgent:
+    """Factory function that wraps the conversation agent with the timer."""
+    return TimedAgent(agent)

--- a/home_assistant_datasets/tool/assist/collect_tests/test_collect.py
+++ b/home_assistant_datasets/tool/assist/collect_tests/test_collect.py
@@ -1,33 +1,24 @@
 """An evaluation for calling Device Actions, expected to be used to evaluate intents."""
 
-import asyncio
 from collections.abc import Callable, Awaitable
-import datetime
 import dataclasses
 import enum
-import json
 import logging
 from typing import Any
 import uuid
 
 import pytest
 import yaml
-from pyrate_limiter import Limiter
 
 from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.components.conversation import trace
 
-from home_assistant_datasets.fixtures import ConversationAgent, EvalRecordWriter
-from home_assistant_datasets.data_model import ModelConfig
-
+from home_assistant_datasets.agent import ConversationAgent
+from home_assistant_datasets.fixtures import EvalRecordWriter
 from home_assistant_datasets.tool.data_model import (
     EvalTask,
     EntityState,
     ModelOutput,
 )
-from home_assistant_datasets.tool.fixtures import dump_conversation_trace
 
 _LOGGER = logging.getLogger(__name__)
 TIMEOUT = 40
@@ -40,8 +31,6 @@ async def test_assist_actions(
     hass: HomeAssistant,
     agent: ConversationAgent,
     eval_record_writer: EvalRecordWriter,
-    model_config: ModelConfig,
-    synthetic_home_config_entry: ConfigEntry,
     eval_task: EvalTask,
     get_state: Callable[[], dict[str, EntityState]],
     verify_state: Callable[
@@ -49,12 +38,8 @@ async def test_assist_actions(
         Awaitable[dict[str, Any]],
     ],
     caplog: pytest.LogCaptureFixture,
-    rate_limiter: Limiter,
 ) -> None:
     """Collects model responses for assist actions."""
-    if rate_limiter:
-        rate_limiter.try_acquire("item")
-
     yaml.SafeDumper.add_multi_representer(
         enum.StrEnum,
         yaml.representer.SafeRepresenter.represent_str,
@@ -63,28 +48,7 @@ async def test_assist_actions(
     states = get_state()
 
     # Run the conversation agent
-    text = eval_task.input_text
-    _LOGGER.debug("Prompt: %s", text)
-    tries = 0
-    response = ""
-    retryable = True
-    duration: datetime.timedelta | None = None
-    while tries < MAX_TRIES and retryable:
-        retryable = False
-        try:
-            async with asyncio.timeout(TIMEOUT):
-                start = datetime.datetime.now()
-                response = await agent.async_process(hass, text)
-                duration = datetime.datetime.now() - start
-        except (HomeAssistantError, TypeError, json.JSONDecodeError) as err:
-            response = str(err)
-        except (TimeoutError, asyncio.CancelledError):
-            _LOGGER.debug("Timeout error (tries=%s)", tries)
-            response = f"Timeout (after {tries} tries)"
-            tries = tries + 1
-            retryable = True
-        await hass.async_block_till_done()
-        _LOGGER.debug("Response: %s", response)
+    response = await agent.async_process(hass, eval_task.input_text)
 
     updated_states = get_state()
     unexpected_states: dict[str, Any] | str
@@ -93,13 +57,8 @@ async def test_assist_actions(
     except ValueError as err:
         unexpected_states = f"Error verifying state: {err}"
 
-    conversation_trace = []
-    if (traces := trace.async_get_traces()) and (last_trace := traces[-1]):
-        conversation_trace = dump_conversation_trace(last_trace)
-
-    extra_context = {}
-    if duration:
-        extra_context["duration_ms"] = duration / datetime.timedelta(milliseconds=1)
+    context = agent.trace_context()
+    context["unexpected_states"] = unexpected_states
 
     output = ModelOutput(
         uuid=str(uuid.uuid4()),  # Unique based on the model evaluated
@@ -114,19 +73,7 @@ async def test_assist_actions(
             "expect_response": eval_task.expect_response,
         },
         response=response,
-        context={
-            "unexpected_states": unexpected_states,
-            "conversation_trace": conversation_trace,
-            # TODO: Would be useful to support something like --dump-states for fully examining states
-            # "state": states,
-            # "updated_states": updated_states,
-            "tries": tries,
-            **extra_context,
-        },
+        context=context,
     )
     _LOGGER.info(output)
     eval_record_writer.write(dataclasses.asdict(output))
-
-    # assert not [
-    #     record.levelname for record in caplog.records if record.levelname == "ERROR"
-    # ]

--- a/home_assistant_datasets/tool/automation/test_collect.py
+++ b/home_assistant_datasets/tool/automation/test_collect.py
@@ -1,29 +1,22 @@
 """An evaluation for calling Device Actions, expected to be used to evaluate intents."""
 
-import asyncio
 import dataclasses
-import datetime
-import json
 import logging
 import uuid
 import textwrap
 
 import pytest
-from pyrate_limiter import Limiter
 
 from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.components.conversation import trace
 
-from home_assistant_datasets.fixtures import ConversationAgent, EvalRecordWriter
-from home_assistant_datasets.data_model import ModelConfig
+from home_assistant_datasets.agent import ConversationAgent
+from home_assistant_datasets.fixtures import EvalRecordWriter
 
 from home_assistant_datasets.tool.data_model import (
     EvalTask,
     ModelOutput,
 )
-from home_assistant_datasets.tool.fixtures import dump_conversation_trace
 
 _LOGGER = logging.getLogger(__name__)
 TIMEOUT = 40
@@ -51,45 +44,12 @@ async def test_assist_actions(
     hass: HomeAssistant,
     agent: ConversationAgent,
     eval_record_writer: EvalRecordWriter,
-    model_config: ModelConfig,
     synthetic_home_config_entry: ConfigEntry,
     eval_task: EvalTask,
-    rate_limiter: Limiter,
 ) -> None:
     """Collects model responses for automation actions."""
-    if rate_limiter:
-        rate_limiter.try_acquire("item")
-
     # Run the conversation agent
-    text = eval_task.input_text
-    _LOGGER.debug("Prompt: %s", text)
-    tries = 0
-    response = ""
-    retryable = True
-    duration: datetime.timedelta | None = None
-    while tries < MAX_TRIES and retryable:
-        retryable = False
-        try:
-            async with asyncio.timeout(TIMEOUT):
-                start = datetime.datetime.now()
-                response = await agent.async_process(hass, text)
-                duration = datetime.datetime.now() - start
-        except (HomeAssistantError, TypeError, json.JSONDecodeError) as err:
-            response = str(err)
-        except (TimeoutError, asyncio.CancelledError):
-            _LOGGER.debug("Timeout error (tries=%s)", tries)
-            response = f"Timeout (after {tries} tries)"
-            tries = tries + 1
-            retryable = True
-        await hass.async_block_till_done()
-        _LOGGER.debug("Response: %s", response)
-
-    conversation_trace = []
-    if (traces := trace.async_get_traces()) and (last_trace := traces[-1]):
-        conversation_trace = dump_conversation_trace(last_trace)
-    extra_context = {}
-    if duration:
-        extra_context["duration_ms"] = duration / datetime.timedelta(milliseconds=1)
+    response = await agent.async_process(hass, eval_task.input_text)
 
     output = ModelOutput(
         uuid=str(uuid.uuid4()),  # Unique based on the model evaluated
@@ -99,11 +59,7 @@ async def test_assist_actions(
             "input_text": eval_task.input_text,
         },
         response=response,
-        context={
-            "conversation_trace": conversation_trace,
-            "tries": tries,
-            **extra_context,
-        },
+        context=agent.trace_context(),
     )
     _LOGGER.info(output)
     eval_record_writer.write(dataclasses.asdict(output))

--- a/home_assistant_datasets/tool/fixtures.py
+++ b/home_assistant_datasets/tool/fixtures.py
@@ -16,9 +16,9 @@ import uuid
 import yaml
 import pytest
 from homeassistant.util import dt as dt_util
-from homeassistant.core import HomeAssistant, Context
+from homeassistant.core import HomeAssistant
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers import device_registry as dr, entity_registry as er, llm
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.components.conversation import trace, async_converse
 
 from home_assistant_datasets.data_model import (
@@ -358,37 +358,6 @@ async def verify_state_fixture(
         return diffs
 
     return func
-
-
-def dump_conversation_trace(trace: trace.ConversationTrace) -> list[dict[str, Any]]:
-    """Serialize the conversation trace for evaluation."""
-    trace_data = trace.as_dict()
-    trace_events = trace_data["events"]
-    result = []
-    for trace_event in trace_events:
-        trace_event_data = trace_event["data"]
-        data = {}
-        for k, v in trace_event_data.items():
-            if isinstance(v, Context):
-                v = dict(v.as_dict())
-            if isinstance(v, list) and v and isinstance(v[0], llm.Tool):
-                v = [
-                    {
-                        "name": tool.name,
-                        "description": tool.description,
-                        "parameters": str(tool.parameters),
-                    }
-                    for tool in v
-                ]
-            data[k] = v
-        values: dict[str, Any] = {
-            "event_type": str(trace_event["event_type"]),
-            "data": data,
-        }
-        if ts_str := trace_event.get("timestamp"):
-            values["timestamp"] = datetime.datetime.fromisoformat(ts_str)
-        result.append(values)
-    return result
 
 
 def find_llm_call(trace_events: list[dict[str, Any]]) -> dict[str, Any] | None:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,6 +6,7 @@ mypy==1.15.0
 synthetic_home==4.6.3
 hass-client==1.2.0
 datasets==3.5.0
+pre-commit==4.2.0
 
 # Dependencies for specific ML integrations
 openai==1.75.0
@@ -20,6 +21,8 @@ home_assistant_intents
 hassil>=2.0.4
 mutagen
 pyspeex_noise>=1.0.2
+pyrate-limiter==3.7.0
+pytest-random-order==1.1.1
 
 # Rely on home-assistant version to pin these
 PyYAML

--- a/requirements_eval.txt
+++ b/requirements_eval.txt
@@ -2,10 +2,6 @@
 ha-ffmpeg
 pymicro-vad
 
-# Framework deps
-pyrate-limiter==3.7.0
-pytest-random-order==1.1.1
-
 # Dependencies for specific ML integrations
 openai
 google-generativeai

--- a/tests/agent/test_init.py
+++ b/tests/agent/test_init.py
@@ -1,0 +1,42 @@
+"""Tests for the agent module."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.exceptions import HomeAssistantError
+
+from home_assistant_datasets.agent import create_default_agent
+
+
+RESPONSE = {"response": {"speech": {"plain": {"speech": "Paris."}}}}
+
+
+async def test_create_default_agent() -> None:
+    """Tests for the default conversation agent."""
+
+    agent = create_default_agent("mock_agent_id")
+
+    mock_hass = AsyncMock()
+    mock_hass.services.async_call.return_value = RESPONSE
+
+    response = await agent.async_process(mock_hass, "What is the capital of france?")
+
+    assert response == "Paris."
+
+    # Just ensure it can run without failing
+    agent.trace_context()
+
+
+async def test_create_default_agent_error() -> None:
+    """Tests for the default conversation agent."""
+
+    agent = create_default_agent("mock_agent_id")
+
+    mock_hass = AsyncMock()
+    mock_hass.services.async_call.side_effect = HomeAssistantError("Fail")
+
+    response = await agent.async_process(mock_hass, "What is the capital of france?")
+
+    assert response == "Fail"
+
+    # Just ensure it can run without failing
+    agent.trace_context()


### PR DESCRIPTION
Move Conversation Agent handling to a submodule. This is a step towards simplifying the eval framework and making it easier to unit test and refactor by moving common logic out of the tool.

This dramatically simplifies the amount of logic running inside the actual tooling body so it can focus on calling the conversation agent only.