### PR TITLE
Fix an ambiguous media player test

### DIFF
--- a/datasets/assist-mini/home7-dk-media-player/media-player.yaml
+++ b/datasets/assist-mini/home7-dk-media-player/media-player.yaml
@@ -3,7 +3,6 @@ category: media-player
 tests:
   - sentences:
       - Pause Outdoor Speakers
-      - Stop the Outdoor Speakers
       - Pause the Rooftop Terrace music
     setup:
       media_player.outdoor_speakers:
@@ -55,3 +54,15 @@ tests:
       media_player.outdoor_speakers:
         attributes:
           volume_level: 0.0
+  - sentences:
+      - Turn off the Outdoor Speakers
+    setup:
+      media_player.outdoor_speakers:
+        state: playing
+    expect_changes:
+      media_player.outdoor_speakers:
+        state: "off"
+    ignore_changes:
+      media_player.outdoor_speakers:
+        - media_track
+        - volume_level

--- a/datasets/assist/home7-dk/media-player.yaml
+++ b/datasets/assist/home7-dk/media-player.yaml
@@ -6,8 +6,6 @@ tests:
       - Pause the music
       - Pause the music outside
       - Pause the Rooftop Terrace music
-      - Stop the Outdoor Speakers
-      - Stop the music
     setup:
       media_player.outdoor_speakers:
         state: playing
@@ -66,3 +64,16 @@ tests:
       media_player.outdoor_speakers:
         attributes:
           volume_level: 0.0
+  - sentences:
+      - Turn off the Outdoor Speakers
+      - Turn off the music
+    setup:
+      media_player.outdoor_speakers:
+        state: playing
+    expect_changes:
+      media_player.outdoor_speakers:
+        state: "off"
+    ignore_changes:
+      media_player.outdoor_speakers:
+        - media_track
+        - volume_level


### PR DESCRIPTION
Stop can either mean pause or turn off, so instead make a separate test that just stops the media player.