### PR TITLE
Fix typo in the curtain tests.

### DIFF
--- a/datasets/assist-mini/home7-dk-cover-curtain/cover-curtain.yaml
+++ b/datasets/assist-mini/home7-dk-cover-curtain/cover-curtain.yaml
@@ -17,7 +17,7 @@ tests:
       cover.smart_curtain:
         - current_position
   - sentences:
-      - Close the smart cutains
+      - Close the smart curtains
       - Close the living room smart curtain
       - Close the living room curtains
     setup:

--- a/datasets/assist/home7-dk/cover-curtain.yaml
+++ b/datasets/assist/home7-dk/cover-curtain.yaml
@@ -15,7 +15,7 @@ tests:
       cover.smart_curtain:
         - current_position
   - sentences:
-      - Close the smart cutains
+      - Close the smart curtains
       - Close the living room curtain
       - Close the curtains
     setup:


### PR DESCRIPTION
Fix typo in the curtain tests. While testing typos can be useful, this is not currently the intent of the test.