### PR TITLE
Ignore derived cover/valve attributes in entity state diff

### DIFF
--- a/home_assistant_datasets/entity_state/diff.py
+++ b/home_assistant_datasets/entity_state/diff.py
@@ -10,6 +10,15 @@ __all__ = [
 ]
 
 
+# get_unexpected_states compares the whole post-action state against the setup
+# snapshot plus the declared expect_changes. Any attribute that changes as a
+# side effect but is not declared gets flagged as unexpected. On covers and
+# valves, is_closed (and is_opening/is_closing) follow from state and position
+# and are never declared, so a correctly actuated device trips a phantom diff.
+# Ignore these; state and position still gate the result.
+DERIVED_STATE_ATTRIBUTES = frozenset({"is_closed", "is_opening", "is_closing"})
+
+
 def compare_state(v: Any, other_v: Any) -> bool:
     """Compare values for equivalence."""
     # Coerce some equivalent types for simpler comparisons
@@ -85,6 +94,7 @@ def get_unexpected_states(
         ignored_attributes = (
             set(ignore_changes.get(entity_id, [])) if ignore_changes else set({})
         )
+        ignored_attributes |= DERIVED_STATE_ATTRIBUTES
         old = states[entity_id]
         new = updated_states[entity_id]
         if diff := compute_entity_diff(old, new, ignored_attributes):

--- a/tests/entity_state/test_diff.py
+++ b/tests/entity_state/test_diff.py
@@ -149,3 +149,73 @@ def test_ignore_attributes_changes() -> None:
     }
 
     assert not diff.get_unexpected_changes()
+
+
+def test_derived_is_closed_ignored() -> None:
+    """A correctly opened valve is not reported as a failure (is_closed is ignored)."""
+
+    mock_get_state = Mock()
+    mock_get_state.get_state.return_value = {
+        "valve.irrigation": EntityState(
+            state="closed",
+            attributes={"current_position": 0, "is_closed": True},
+        ),
+    }
+
+    diff = EntityStateDiffFixture(mock_get_state)
+    diff.prepare(
+        {
+            "valve.irrigation": EntityState(
+                state="open",
+                attributes={"current_position": 100},
+            ),
+        },
+        {},
+    )
+
+    mock_get_state.get_state.return_value = {
+        "valve.irrigation": EntityState(
+            state="open",
+            attributes={"current_position": 100, "is_closed": False},
+        ),
+    }
+
+    assert not diff.get_unexpected_changes()
+
+
+def test_derived_attributes_do_not_mask_real_failure() -> None:
+    """A valve that never changed is still reported as a failure."""
+
+    mock_get_state = Mock()
+    mock_get_state.get_state.return_value = {
+        "valve.irrigation": EntityState(
+            state="closed",
+            attributes={"current_position": 0, "is_closed": True},
+        ),
+    }
+
+    diff = EntityStateDiffFixture(mock_get_state)
+    diff.prepare(
+        {
+            "valve.irrigation": EntityState(
+                state="open",
+                attributes={"current_position": 100},
+            ),
+        },
+        {},
+    )
+
+    # Model did not act; the valve is still closed.
+    mock_get_state.get_state.return_value = {
+        "valve.irrigation": EntityState(
+            state="closed",
+            attributes={"current_position": 0, "is_closed": True},
+        ),
+    }
+
+    assert diff.get_unexpected_changes() == {
+        "valve.irrigation": {
+            "expected": {"current_position": 100, "state": "open"},
+            "got": {"current_position": 0, "state": "closed"},
+        }
+    }


### PR DESCRIPTION
The eval state diff reports a phantom change on every cover and valve open/close task, so they fail even when the device ends in the correct state. This drops both categories to 0%. The fix ignores the derived `is_closed`/`is_opening`/`is_closing` attributes when computing the diff.

The root cause is that `get_unexpected_states` builds the expected end state from the setup snapshot, overrides only the attributes a task declares in `expect_changes`, then compares the whole attribute set against the actual post-action state. Any attribute that changes as a side effect of the declared change, but is not itself declared, is reported as unexpected.

On covers and valves, `is_closed` (and `is_opening`/`is_closing`) follow from `state` and `current_position`. A task asserts `state` and position but never the derived booleans, so opening a valve leaves the expected `is_closed` at its stale setup value of true while the actual value is false. That mismatch fails the task.

The diff has always made this assumption, but it only bites once an entity reports `is_closed` as a state attribute. Home Assistant core began including it in cover and valve `state_attributes` (`data[ATTR_IS_CLOSED] = self.is_closed`), so runs on recent cores capture it while older runs did not. For example, the gemma4-e4b run on 2026.2.3 has no `is_closed` in its captured states and scored cover/valve normally; the 2026.6.0b2 run captures it, and both categories read 0%.

This PR adds `is_closed`, `is_opening`, and `is_closing` to the ignored attributes in the diff. `state` and `current_position` are still compared, so a genuinely missed action still fails. This is a targeted fix for the known derived attributes, not a change to the diff's general assumption that non-declared attributes should not change.

Tested with new regression cases and the full test suite, which shows no new failures from this change.