### PR TITLE
Restore DNS resolution for live LLM tests

### DIFF
--- a/home_assistant_datasets/plugins/pytest_agent.py
+++ b/home_assistant_datasets/plugins/pytest_agent.py
@@ -9,6 +9,8 @@ specific agent configuration needed.
 
 import dataclasses
 import logging
+import socket
+from collections.abc import Generator
 from typing import Any
 
 import pytest
@@ -16,6 +18,7 @@ import pytest_socket
 from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component import plugins as phcc_plugins
 
 from home_assistant_datasets.agent import (
     ConversationAgent,
@@ -44,14 +47,43 @@ _LOGGER = logging.getLogger(__name__)
 
 
 @pytest.fixture(autouse=True)
-def mock_allow_sockets(socket_enabled: Any) -> None:
+def mock_allow_sockets(socket_enabled: Any) -> Generator[None, None, None]:
     """Remove all restrictions talking to sockets.
 
     This is needed when talking to external data sources
     like LLMs.
+
+    Home Assistant's test harness restricts the network in two independent
+    ways (see `pytest_homeassistant_custom_component.plugins`):
+
+    1. `pytest_socket.socket_allow_hosts(["127.0.0.1"])` plus `disable_socket()`
+    2. since Home Assistant 2026.5.0, `socket.getaddrinfo`, `gethostbyname` and
+       `gethostbyname_ex` are patched to reject any host that is not an IP
+       literal, raising `RuntimeError("DNS resolution disabled in tests")`
+
+    Lifting only (1) leaves every hostname unresolvable, which surfaces from
+    the openai SDK as the generic `APIConnectionError("Connection error.")` and
+    from Home Assistant as `ConfigEntryNotReady` - so the real cause never
+    reaches the logs.
     """
+    saved = (socket.getaddrinfo, socket.gethostbyname, socket.gethostbyname_ex)
+
     pytest_socket.pytest_runtest_teardown()
-    pass
+
+    real_getaddrinfo = phcc_plugins._real_getaddrinfo
+    socket.getaddrinfo = real_getaddrinfo
+    socket.gethostbyname = lambda host, *args, **kwargs: real_getaddrinfo(host, None)[
+        0
+    ][4][0]
+    socket.gethostbyname_ex = lambda host, *args, **kwargs: (
+        host,
+        [],
+        [real_getaddrinfo(host, None)[0][4][0]],
+    )
+    try:
+        yield
+    finally:
+        socket.getaddrinfo, socket.gethostbyname, socket.gethostbyname_ex = saved
 
 
 @pytest.fixture(scope="module")
@@ -109,6 +141,7 @@ def merged_model_config_fixture(
 
 @pytest.fixture(name="conversation_agent_config_entry")
 async def mock_conversation_agent_config_entry(
+    mock_allow_sockets: None,
     hass: HomeAssistant,
     merged_model_config: ModelConfig,
 ) -> MockConfigEntry | None:


### PR DESCRIPTION
## The problem

Every model whose agent talks to a remote API currently fails collection with all tests erroring at:

```
assert config_entry.state == ConfigEntryState.LOADED
AssertionError: assert <ConfigEntryState.SETUP_RETRY> == <ConfigEntryState.LOADED>
```

The logs only ever show:

```
INFO openai._base_client: Retrying request to /models in 0.48s
INFO homeassistant.config_entries: Config entry 'Mock Title' for open_router
     integration not ready yet: Connection error.; Retrying in 5 seconds
```

The real cause is hidden three layers down. Unwrapping `__cause__`:

```
openai.APIConnectionError: Connection error.
  <- RuntimeError: DNS resolution disabled in tests
  <- ValueError: b'openrouter.ai' does not appear to be an IPv4 or IPv6 address
```

`pytest_homeassistant_custom_component.plugins.pytest_runtest_setup` restricts the network **twice**:

1. `pytest_socket.socket_allow_hosts(["127.0.0.1"])` + `disable_socket(...)`
2. since HA 2026.5.0, `socket.getaddrinfo` / `gethostbyname` / `gethostbyname_ex` are patched to reject any host that isn't an IP literal

`mock_allow_sockets` lifts only (1), so hostnames stay unresolvable. I hit (2) from the other side while fixing this: repairing DNS alone still fails, because the `["127.0.0.1"]` allowlist then rejects the `connect()`. Both have to go.

`tests/conftest.py` in home-assistant/core has no such guard in 2026.1.1 / 2026.2.3 / 2026.3.0 / 2026.4.0, and has it from 2026.5.0 onward.

## The change

- `mock_allow_sockets` becomes a generator fixture: it lifts the socket restrictions as before, points the patched DNS helpers back at `plugins._real_getaddrinfo`, and restores the harness patches on teardown so unrelated tests stay sandboxed.
- `conversation_agent_config_entry` now takes `mock_allow_sockets` as an explicit dependency. It creates the config entry — and so makes the first network call — during *fixture setup*, so leaving the ordering to autouse resolution between two fixtures is a race. I confirmed this empirically: a fix that only works for calls made in the test body still fails when the call happens in a fixture.

## Testing

Against HA 2026.7.4 / phcc 0.13.348 / openai 2.53.0, using a dummy API key throughout (`openrouter.ai/api/v1/models` is public, so a reachable socket returns 200):

| case | result |
|---|---|
| control, outside pytest | OK — request completed |
| in pytest, no fixture | `DNS resolution disabled in tests` |
| in pytest, `socket_enabled` only | `DNS resolution disabled in tests` |
| in pytest, `mock_allow_sockets` before this change | `DNS resolution disabled in tests` |
| via `homeassistant.helpers.httpx_client.get_async_client`, as `open_router` does | `DNS resolution disabled in tests` |
| **with this change** | **OK — request completed** |

Verified through this repo's actual `pytest_agent` plugin, in both directions: the call succeeds with the patch and fails with it reverted.

`pytest tests/` — 130 passed, 3 failed, 1 skipped, identical to baseline on `main` (`test_synthetic_home_fixture`, `test_assist`, `test_automation` fail without this change too). `ruff check` and `ruff format --check` clean; `ty` reports the same single pre-existing `unresolved-import: custom_components` as baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)